### PR TITLE
Wrong table definition for delayed Job

### DIFF
--- a/lib/thinking_sphinx/deltas/delayed_delta/job.rb
+++ b/lib/thinking_sphinx/deltas/delayed_delta/job.rb
@@ -2,6 +2,7 @@ module Delayed
   module Backend
     module ActiveRecord
       class Job < ::ActiveRecord::Base
+        set_table_name :delayed_jobs      
       end
     end
   end


### PR DESCRIPTION
In my project, I have my own 'Job' AR class. It took me hours to find out why 'Delayed' Job got the wrong table definition, causing errors like 'missing property: priority'. This change fixes the problem by properly setting the table name of the class.
