### PR TITLE
config file cannot be found, space in path

### DIFF
--- a/lib/thinking_sphinx/deltas/delayed_delta/delta_job.rb
+++ b/lib/thinking_sphinx/deltas/delayed_delta/delta_job.rb
@@ -25,7 +25,7 @@ class ThinkingSphinx::Deltas::DeltaJob
   def perform
     config = ThinkingSphinx::Configuration.instance
     
-    output = `#{config.bin_path}#{config.indexer_binary_name} --config #{config.config_file} --rotate #{indexes.join(' ')}`
+    output = `#{config.bin_path}#{config.indexer_binary_name} --config "#{config.config_file}" --rotate #{indexes.join(' ')}`
     puts output unless ThinkingSphinx.suppress_delta_output?
     
     true


### PR DESCRIPTION
I had a problem with ts-delayed-delta finding my config file as my project was within a directory which has spaces. Yeah I know that's evil, but I fixed up ts-delayed-delta to work.

from
Mick
