### PR TITLE
Rails 3.x improvement: do not force requiring tasks in Rakefile

### DIFF
--- a/lib/thinking_sphinx/deltas/delayed_delta/engine.rb
+++ b/lib/thinking_sphinx/deltas/delayed_delta/engine.rb
@@ -1,0 +1,14 @@
+module ThinkingSphinx
+  module Deltas
+
+      class DelayedDelta::Engine < Rails::Engine
+        engine_name :ts_delayed_delta
+
+        rake_tasks do
+          load "thinking_sphinx/deltas/delayed_delta/railties/tasks.rake"
+        end
+      end
+
+  end
+end
+

--- a/lib/thinking_sphinx/deltas/delayed_delta/railties/tasks.rake
+++ b/lib/thinking_sphinx/deltas/delayed_delta/railties/tasks.rake
@@ -1,0 +1,23 @@
+namespace :thinking_sphinx do
+  task :index do
+    require 'thinking_sphinx/deltas/delayed_delta'
+    ThinkingSphinx::Deltas::Job.cancel_thinking_sphinx_jobs
+  end
+
+  desc "Process stored delta index requests"
+  task :delayed_delta => :app_env do
+    require 'delayed_job'
+    require 'delayed/worker'
+    require 'thinking_sphinx/deltas/delayed_delta'
+    Delayed::Worker.new(
+      :min_priority => ENV['MIN_PRIORITY'],
+      :max_priority => ENV['MAX_PRIORITY']
+    ).start
+  end
+end
+
+namespace :ts do
+  desc "Process stored delta index requests"
+  task :dd => "thinking_sphinx:delayed_delta"
+end
+

--- a/lib/ts-delayed-delta.rb
+++ b/lib/ts-delayed-delta.rb
@@ -1,0 +1,4 @@
+require 'thinking_sphinx'
+require 'delayed_job'
+require 'thinking_sphinx/deltas/delayed_delta'
+require 'thinking_sphinx/deltas/delayed_delta/engine' if defined?(Rails) && Rails::VERSION::MAJOR == 3


### PR DESCRIPTION
Pat, 
these changes should get a rails 3.x user up to speed faster, since tasks are automatically loaded using railties as opposed to requiring them in the rails app's Rakefile...
