### PR TITLE
Added queue parameter for creating jobs

### DIFF
--- a/lib/thinking_sphinx/deltas/delayed_delta.rb
+++ b/lib/thinking_sphinx/deltas/delayed_delta.rb
@@ -38,14 +38,17 @@ class ThinkingSphinx::Deltas::DelayedDelta < ThinkingSphinx::Deltas::DefaultDelt
 
     ThinkingSphinx::Deltas::Job.enqueue(
       ThinkingSphinx::Deltas::DeltaJob.new(model.delta_index_names),
-      ThinkingSphinx::Configuration.instance.delayed_job_priority
+      ThinkingSphinx::Configuration.instance.delayed_job_priority,
+      ThinkingSphinx::Deltas::DelayedDelta.queue_name
     )
 
     options = if Gem.loaded_specs['delayed_job'].version.to_s.match(/^2\.0\./)
       # Fallback for compatibility with old release 2.0.x of DJ
       ThinkingSphinx::Configuration.instance.delayed_job_priority
     else
-      { :priority => ThinkingSphinx::Configuration.instance.delayed_job_priority }
+      { :priority => ThinkingSphinx::Configuration.instance.delayed_job_priority,
+        :queue    => ThinkingSphinx::Deltas::DelayedDelta.queue_name
+      }
     end
 
     Delayed::Job.enqueue(
@@ -58,7 +61,14 @@ class ThinkingSphinx::Deltas::DelayedDelta < ThinkingSphinx::Deltas::DefaultDelt
     true
   end
 
+
+  def self.queue_name
+    "thinking_sphinx_delayed_delta"
+  end
+  
   private
+  
+
 
   # Checks whether jobs should be enqueued. Only true if updates and deltas are
   # enabled, and the instance (if there is one) is toggled.

--- a/lib/thinking_sphinx/deltas/delayed_delta/job.rb
+++ b/lib/thinking_sphinx/deltas/delayed_delta/job.rb
@@ -26,12 +26,12 @@ class ThinkingSphinx::Deltas::Job < Delayed::Backend::ActiveRecord::Job
   # @param [Object] object The job, which must respond to the #perform method.
   # @param [Integer] priority (0)
   # 
-  def self.enqueue(object, priority = 0)
+  def self.enqueue(object, priority = 0, queue = "")
     options = if Gem.loaded_specs['delayed_job'].version.to_s.match(/^2\.0\./)
       # Fallback for compatibility with old release 2.0.x of DJ
       priority
     else
-      { :priority => priority }
+      { :priority => priority, :queue => queue }
     end
       
     ::Delayed::Job.enqueue(object, options) unless duplicates_exist(object)

--- a/lib/thinking_sphinx/deltas/delayed_delta/tasks.rb
+++ b/lib/thinking_sphinx/deltas/delayed_delta/tasks.rb
@@ -12,7 +12,8 @@ namespace :thinking_sphinx do
 
     Delayed::Worker.new(
       :min_priority => ENV['MIN_PRIORITY'],
-      :max_priority => ENV['MAX_PRIORITY']
+      :max_priority => ENV['MAX_PRIORITY'],
+      :queue       => ThinkingSphinx::Deltas::DelayedDelta.queue_name
     ).start
   end
 end


### PR DESCRIPTION
Hi,
In a multi-server setup we missed the ability to name the queue's, so only the thinking sphinx server would pick up the index jobs.

Kind regards and thanks for all the work.

Sander
