### PR TITLE
Fixes "NoMethodError: undefined method `connection' for #<ThinkingSphinx::Configuration:0x007fdb75d89c78>"

### DIFF
--- a/lib/thinking_sphinx/deltas/delayed_delta/flag_as_deleted_job.rb
+++ b/lib/thinking_sphinx/deltas/delayed_delta/flag_as_deleted_job.rb
@@ -26,9 +26,9 @@ class ThinkingSphinx::Deltas::DelayedDelta::FlagAsDeletedJob
   # @return [Boolean] true
   #
   def perform
-    ThinkingSphinx::Configuration.instance.connection.query(
-      Riddle::Query.update(@index, @document_id, :sphinx_deleted => true)
-    )
+    ThinkingSphinx::Connection.take do |connection|
+      connection.query Riddle::Query.update(@index, @document_id, :sphinx_deleted => true)
+    end
   rescue Mysql2::Error => error
     # This isn't vital, so don't raise the error
   end

--- a/ts-delayed-delta.gemspec
+++ b/ts-delayed-delta.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   }
   s.require_paths = ['lib']
 
-  s.add_runtime_dependency 'thinking-sphinx', '>= 3.0.0.pre'
+  s.add_runtime_dependency 'thinking-sphinx', '>= 3.0.1'
   s.add_runtime_dependency 'delayed_job',     '>= 3.0.0'
 
   s.add_development_dependency 'database_cleaner',          '~> 0.7.1'


### PR DESCRIPTION
With TS 3.0.1 and ts-delayed-delta edge, I get the following error when running a FlagAsDeletedJob:

`NoMethodError: undefined method`connection' for #ThinkingSphinx::Configuration:0x007fdb75d89c78`

This fixes it. I have no idea if it does it in the way that you want it to do it, and am happy to change it if you tell me how you'd prefer it. Equally, there seem to be no real tests on edge so I've not included any. If you tell me how you'd like them, I'm happy to write them too :)

Thanks for all your hard work with TS.
iHiD
