### PR TITLE
Ability to specify other delayed job attributes - also handled code change suggestions

### DIFF
--- a/lib/thinking_sphinx/deltas/delayed_delta.rb
+++ b/lib/thinking_sphinx/deltas/delayed_delta.rb
@@ -46,8 +46,8 @@ class ThinkingSphinx::Deltas::DelayedDelta <
       # Only priority option is supported for these versions
       set_job_options(:delayed_job_priority)
     else
-      CONFIGURATIONS_MAP.inject({}) do |dj_mapper, configuration_entity|
-        dj_mapper.merge(configuration_entity[0] => set_job_options(configuration_entity[1]))
+      CONFIGURATIONS_MAP.inject({}) do |job_mapper, configuration_entity|
+        job_mapper.merge(configuration_entity[0] => set_job_options(configuration_entity[1]))
       end
     end
   end


### PR DESCRIPTION
Pat,

I have made the suggested changes. Also, I noticed a method called self.cancel_jobs. which can potentially delete records even when a delta job is being processed by any worker. So this may corrupt the indices. Also, failed_at jobs should not be cleared as they will serve debugging purposes.
