### PR TITLE
Fixed wrong number of arguments (2 for 1) when running ts:index

### DIFF
--- a/lib/thinking_sphinx/deltas/delayed_delta.rb
+++ b/lib/thinking_sphinx/deltas/delayed_delta.rb
@@ -20,10 +20,8 @@ class ThinkingSphinx::Deltas::DelayedDelta <
   }
 
   def self.cancel_jobs
-    Delayed::Job.delete_all(
-      "handler LIKE '--- !ruby/object:ThinkingSphinx::Deltas::%'",
-      :conditions => {:locked_at => nil, :locked_by => nil, :failed_at => nil}
-    )
+    Delayed::Job.where("handler LIKE '--- !ruby/object:ThinkingSphinx::Deltas::%'")
+                .where(:locked_at => nil, :locked_by => nil, :failed_at => nil).delete_all
   end
 
   def self.enqueue_unless_duplicates(object)


### PR DESCRIPTION
Fixed this error:

```
wrong number of arguments (2 for 1)
/home/bitnami/.bundler/ruby/1.9.1/ts-delayed-delta-5462f126db4a/lib/thinking_sphinx/deltas/delayed_delta.rb:23:in `cancel_jobs'
/home/bitnami/.bundler/ruby/1.9.1/ts-delayed-delta-5462f126db4a/lib/thinking_sphinx/deltas/delayed_delta.rb:145:in `block in <top (required)>'
Tasks: TOP => ts:index
```

by changing request to Delayed::Job in cancel_job method a little bit
