### PR TITLE
Create a new job if there is an existing job which has failed

### DIFF
--- a/lib/thinking_sphinx/deltas/delayed_delta.rb
+++ b/lib/thinking_sphinx/deltas/delayed_delta.rb
@@ -23,11 +23,11 @@ class ThinkingSphinx::Deltas::DelayedDelta <
   def self.enqueue_unless_duplicates(object)
     if Delayed::Job.respond_to?(:where)
       return if Delayed::Job.where(
-        :handler => object.to_yaml, :locked_at => nil
+        :handler => object.to_yaml, :locked_at => nil, :failed_at => nil
       ).count > 0
     else
       return if Delayed::Job.count(
-        :conditions => {:handler => object.to_yaml, :locked_at => nil}
+        :conditions => {:handler => object.to_yaml, :locked_at => nil, :failed_at => nil}
       ) > 0
     end
 


### PR DESCRIPTION
Hi!

The delta indexing stop suddenly working for us. We debugged the issue and found a reason:

For debugging and logging purposes, we have configured Delayed Job to keep all failed jobs in `delayed_jobs` table. We found out that if a delta indexing job fails, no new jobs are created. We changed the `where` condition to take into account a situation where we have an existing failed job in `delayed_jobs` table.
