### PR TITLE
Fix Rails 5 deprecation in cancel_jobs

### DIFF
--- a/lib/thinking_sphinx/deltas/delayed_delta.rb
+++ b/lib/thinking_sphinx/deltas/delayed_delta.rb
@@ -15,9 +15,16 @@ class ThinkingSphinx::Deltas::DelayedDelta <
   ThinkingSphinx::Deltas::DefaultDelta
 
   def self.cancel_jobs
-    Delayed::Job.delete_all([
+    where_clause = [
       "handler LIKE (?) AND locked_at IS NULL AND locked_by IS NULL AND failed_at IS NULL", "--- !ruby/object:ThinkingSphinx::Deltas::%"
-    ])
+    ]
+    if Delayed::Job.respond_to?(:where)
+      # Supported in Rails 3 and up.
+      Delayed::Job.where(where_clause).delete_all
+    else
+      # Supported from Rails 2, deprecated in Rails 5.1.
+      Delayed::Job.delete_all(where_clause)
+    end
   end
 
   def self.enqueue_unless_duplicates(object)

--- a/lib/thinking_sphinx/deltas/delayed_delta.rb
+++ b/lib/thinking_sphinx/deltas/delayed_delta.rb
@@ -22,7 +22,7 @@ class ThinkingSphinx::Deltas::DelayedDelta <
       # Supported in Rails 3 and up.
       Delayed::Job.where(where_clause).delete_all
     else
-      # Supported from Rails 2, deprecated in Rails 5.1.
+      # Supported from Rails 2, deprecated in Rails 5.
       Delayed::Job.delete_all(where_clause)
     end
   end

--- a/ts-delayed-delta.gemspec
+++ b/ts-delayed-delta.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'thinking-sphinx',               '>= 1.5.0'
   s.add_runtime_dependency 'delayed_job'
+  s.add_runtime_dependency 'activerecord',                  '>= 2.0'
 
   s.add_development_dependency 'appraisal',                 '~> 0.5.2'
   s.add_development_dependency 'combustion',                '~> 0.4.0'


### PR DESCRIPTION
```
jason@jason-X550CA:/www/greasyfork$ rake ts:index
Generating configuration to /www/greasyfork/config/development.sphinx.conf
rake aborted!
ActiveSupport::DeprecationException: DEPRECATION WARNING: Passing conditions to delete_all is deprecated and will be removed in Rails 5.1. To achieve the same use where(conditions).delete_all. (called from load at /home/jason/.rvm/gems/ruby-2.3.1@greasyfork/bin/rake:22)
/home/jason/.rvm/gems/ruby-2.3.1@greasyfork/gems/activerecord-5.0.0.1/lib/active_record/relation.rb:528:in `delete_all'
/home/jason/.rvm/gems/ruby-2.3.1@greasyfork/gems/newrelic_rpm-3.16.3.323/lib/new_relic/agent/instrumentation/active_record_helper.rb:54:in `block in delete_all'
/home/jason/.rvm/gems/ruby-2.3.1@greasyfork/gems/newrelic_rpm-3.16.3.323/lib/new_relic/agent.rb:586:in `with_database_metric_name'
/home/jason/.rvm/gems/ruby-2.3.1@greasyfork/gems/newrelic_rpm-3.16.3.323/lib/new_relic/agent/instrumentation/active_record_helper.rb:53:in `delete_all'
/home/jason/.rvm/gems/ruby-2.3.1@greasyfork/gems/activerecord-5.0.0.1/lib/active_record/querying.rb:8:in `delete_all'
/home/jason/.rvm/gems/ruby-2.3.1@greasyfork/gems/ts-delayed-delta-2.0.2/lib/thinking_sphinx/deltas/delayed_delta.rb:18:in `cancel_jobs'
/home/jason/.rvm/gems/ruby-2.3.1@greasyfork/gems/ts-delayed-delta-2.0.2/lib/thinking_sphinx/deltas/delayed_delta.rb:142:in `block in <top (required)>'
/home/jason/.rvm/gems/ruby-2.3.1@greasyfork/gems/thinking-sphinx-3.2.0/lib/thinking_sphinx/rake_interface.rb:37:in `block in index'
/home/jason/.rvm/gems/ruby-2.3.1@greasyfork/gems/thinking-sphinx-3.2.0/lib/thinking_sphinx/rake_interface.rb:37:in `each'
/home/jason/.rvm/gems/ruby-2.3.1@greasyfork/gems/thinking-sphinx-3.2.0/lib/thinking_sphinx/rake_interface.rb:37:in `index'
/home/jason/.rvm/gems/ruby-2.3.1@greasyfork/gems/thinking-sphinx-3.2.0/lib/thinking_sphinx/tasks.rb:9:in `block (2 levels) in <top (required)>'
/home/jason/.rvm/gems/ruby-2.3.1@greasyfork/gems/rake-11.3.0/exe/rake:27:in `<top (required)>'
/home/jason/.rvm/gems/ruby-2.3.1@greasyfork/bin/ruby_executable_hooks:15:in `eval'
/home/jason/.rvm/gems/ruby-2.3.1@greasyfork/bin/ruby_executable_hooks:15:in `<main>'
Tasks: TOP => ts:index
(See full trace by running task with --trace)
```

This PR fixes that. The rest of the code seems to support all the way back to Rails 2, so I've maintained that support.

I also added a missing dependency on activerecord. This would've been included because it comes comes with thinking-sphinx anyway, but since we're referencing activerecord stuff it seems correct to specify it.
